### PR TITLE
[DO NOT MERGE] build experiments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y \
 
 # Install Hadoop
 RUN cd /tmp \
-    && curl -Lo - http://ftp.unicamp.br/pub/apache/hadoop/common/hadoop-3.0.0/hadoop-3.0.0.tar.gz | tar -xz \
+    && curl -Lo - https://archive.apache.org/dist/hadoop/core/hadoop-3.0.0/hadoop-3.0.0.tar.gz | tar -xz \
     && mv hadoop-3.0.0 /usr/local/hadoop 
 
 ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"

--- a/aggregate/spark_aggregate.js
+++ b/aggregate/spark_aggregate.js
@@ -13,15 +13,20 @@ exports.aggregate = (file, aggregation_level, path_unzipped, path_temp) => {
     ',' + path_unzipped + ',' + path_temp +
     '" >> spark.output'
 
-    exec(
-      command, (error, stdout, stderr) => {
-        util.print('stdout: ' + stdout)
-        util.print('stderr: ' + stderr)
-        if (error !== null) {
+      try {
+          exec(
+              command, (error, stdout, stderr) => {
+                  util.print('stdout: ' + stdout)
+                  util.print('stderr: ' + stderr)
+                  if (error !== null) {
+                      throw error
+                  }
+                  console.log('DONE!')
+                  resolve()
+              })
+      } catch (error) {
           console.log('exec error: ' + error)
-        }
-        console.log('DONE!')
-        resolve()
-      })
+          reject()
+      }
   })
 }


### PR DESCRIPTION
…reject()

So the failure bubbles up through the promise chain.
Specifically this helps ensure test failures created by exec failures are registered
Also to get to the point where the tests are running: fix hadoop path