### PR TITLE
Add global error handling and fix path in spark process

### DIFF
--- a/combine_spark_output.js
+++ b/combine_spark_output.js
@@ -72,7 +72,7 @@ const process_file = (
       // Split line by ',' and map items to fields: ['year', 'week', 'count', 'origin', 'destination']
       // vals is an object: {year: 2017, week: 3, origin: 'US', destination: 'MX', cnt: 100}
       let vals = l.split(/,/).reduce((h, val, index) => {
-        h[fields[index++]] = val
+        h[fields[index]] = val
         return h
       }, {})
 

--- a/main.js
+++ b/main.js
@@ -92,6 +92,10 @@ async.waterfall([
       return process_file(file, date_lookup)
     }, {concurreny: 1})
     .then(callback)
+    .catch( (err) => {
+        console.log('Failed, bailing out...')
+        process.exit(1)
+    })
   }
 ], () => {
     console.log('Done with all!')
@@ -132,6 +136,8 @@ const process_file = (file, date_lookup) => {
           path_temp
         ).then(() => {
           callback(null, unzipped_file)
+        }).catch((e) => {
+          reject(e)
         })
       },
 
@@ -150,6 +156,7 @@ const process_file = (file, date_lookup) => {
         )
         .catch((err) => {
           console.log(err)
+          reject(err)
         })
         .then(() => {
           console.log('Done combining')
@@ -162,4 +169,3 @@ const process_file = (file, date_lookup) => {
       }, 1)
   })
 }
-

--- a/spark/aggregate.scala
+++ b/spark/aggregate.scala
@@ -63,7 +63,7 @@ val path_temp = paramsArray(3)
 
 // Create RDD from CSV file
 // RDD for mobility data
-val mobil = sqlContext.read.format("com.databricks.spark.csv").option("header", "true").option("inferSchema", "true").option("delimiter", "\t").load(path_unzipped + filename)
+val mobil = sqlContext.read.format("com.databricks.spark.csv").option("header", "true").option("inferSchema", "true").option("delimiter", "\t").load(path_unzipped + "/" + filename)
 mobil.registerTempTable("mobils")
 
 // Run the query


### PR DESCRIPTION
This pull request consists out of 3 commits. 

* Added global exception handling, and making sure the process exits with an error status. In combination with the https://github.com/unicef/magicbox-aggregate-mobility/pull/33 pull request, travis should also fail if something inside running process failed.

* Fix loading the actual data in spark; in my environment this fails due to missing an '/' after the path. I added an extra '/' which will make sure it will work in any occasion.

* Small fix on the combine_spark_output.js where there was some redundant code incrementing an index variable (which made it a bit vague, almost implying arrays start at 1 ;-)

Gr., Vincent